### PR TITLE
docs(gh-pages): fix the gh-pages deployment and add readme link

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -36,5 +36,5 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
-        publish_dir: ./target/doc/safe_network_signature_aggregator
+        publish_dir: ./target/doc/
         force_orphan: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # BLS Signature Aggregator
 A Generic BLS Signature Aggregator.
 
+| [Documentation](https://maidsafe.github.io/bls_signature_aggregator/bls_signature_aggregator) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+|:----------------------------------------:|:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
+
 ## License
 
 This SAFE Network software is dual-licensed under the Modified BSD ([LICENSE-BSD](LICENSE-BSD) https://opensource.org/licenses/BSD-3-Clause) or the MIT license ([LICENSE-MIT](LICENSE-MIT) http://opensource.org/licenses/MIT) at your option.


### PR DESCRIPTION
Seems images are not being displayed on `https://maidsafe.github.io/safe-network-signature-aggregator/` so checked and it's because the CI deploys the /taget/docs/safe-network-signature-aggregator/ dir to the gh-pages branch as that is where the index.html is, however it is then missing the files in the /target/docs/ dir.

Solution seems to be to update to deploy the /target/docs/ dir instead, but to add a link in the readme to `https://maidsafe.github.io/safe-network-signature-aggregator/safe-network-signature-aggregator` (similar has been done in routing)

UPDATE: repo in process of being renamed to `bls_signature_aggregator`, have updated README links in this PR accordingly.