### PR TITLE
Repeated aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,6 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "err-derive",
- "log",
  "rand",
  "serde",
  "sn_fake_clock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "bls_signature_aggregator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "err-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "bls_signature_aggregator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bincode",
  "err-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2018"
 bincode = "1.2.1"
 err-derive = "~0.2.4"
 sn_fake_clock = "~0.4.0"
-log = "~0.4.8"
 rand = "~0.7.3"
 threshold_crypto = "~0.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.2.1"
 err-derive = "~0.2.4"
-sn_fake_clock = "~0.4.0"
+sn_fake_clock = { version = "~0.4.0", optional = true }
 rand = "~0.7.3"
 threshold_crypto = "~0.4.0"
 
@@ -25,4 +25,4 @@ threshold_crypto = "~0.4.0"
   features = [ "sha3" ]
 
 [features]
-mock_timer = [ ]
+mock_timer = ["sn_fake_clock"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,18 @@ edition = "2018"
 bincode = "1.2.1"
 err-derive = "~0.2.4"
 sn_fake_clock = { version = "~0.4.0", optional = true }
-rand = "~0.7.3"
 threshold_crypto = "~0.4.0"
 
   [dependencies.serde]
   version = "1.0.111"
-  features = [ "derive", "rc" ]
+  features = [ "derive" ]
 
   [dependencies.tiny-keccak]
   version = "2.0.2"
   features = [ "sha3" ]
+
+[dev-dependencies]
+rand = "~0.7.3"
 
 [features]
 mock_timer = ["sn_fake_clock"]

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -74,8 +74,8 @@ impl Debug for ProofShare {
 
 #[cfg(test)]
 mod tests {
-    use crate::Proof;
-    use threshold_crypto::SecretKey;
+    use crate::{Proof};
+    use threshold_crypto::{SecretKey};
 
     #[test]
     fn verify_proof() {

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -74,8 +74,8 @@ impl Debug for ProofShare {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Proof};
-    use threshold_crypto::{SecretKey};
+    use crate::Proof;
+    use threshold_crypto::SecretKey;
 
     #[test]
     fn verify_proof() {

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -340,7 +340,7 @@ mod tests {
         }
 
         let proof_share = create_proof_share(&sk_set, threshold + offset + 1, &payload);
-        assert!(accumulator.add(payload.clone(), proof_share).is_ok());
+        assert!(accumulator.add(payload, proof_share).is_ok());
     }
 
     fn create_proof_share<T: Serialize>(

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -61,7 +61,7 @@ pub const DEFAULT_EXPIRATION: Duration = Duration::from_secs(120);
 /// otherwise lead to invalid signature to be produced even though all the shares are valid.
 ///
 pub struct SignatureAggregator {
-    map: HashMap<(Digest256, bls::PublicKey), State>,
+    map: HashMap<Digest256, State>,
     expiration: Duration,
 }
 
@@ -115,11 +115,9 @@ impl SignatureAggregator {
         let public_key = proof_share.public_key_set.public_key();
         bytes.extend_from_slice(&public_key.to_bytes());
         let hash = sha3_256(&bytes);
-        let public_key = proof_share.public_key_set.public_key();
-        let key = (hash, public_key);
 
         self.map
-            .entry(key)
+            .entry(hash)
             .or_insert_with(State::new)
             .add(payload, proof_share)
             .map(|(payload, signature)| {


### PR DESCRIPTION
This PR modifies the crate to support multiple aggregation of the same payload. It also makes the `SignatureAggregator` type non-generic because we actually don't need to store the payload inside it. This should make it slightly easier to use and marginally faster to compile. Finally it reverts the change to make `PublicKey` part of the map key because it was redundant.