### PR TITLE
docs(gh-pages): update CI to keep existing gh-pages branch content

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -37,4 +37,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_branch: gh-pages
         publish_dir: ./target/doc/
-        force_orphan: true
+        keep_files: true


### PR DESCRIPTION
Why is this needed? We are having to add a custom index.html in
the root gh-pages branch, pointing to the index.html in a
subfolder. Without `keep_files: true` all existing files are
removed - we need this set to true so the index.html file remains.

Note that `force_orphan: true` and `keep_files: true` are not
compatible in the action v3, but will be in v4, hence the need to
delete `force_orphan: true`.