### PR TITLE
Add additional code lints scan

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,12 +51,43 @@ jobs:
       - name: Clippy checks
         run: cargo clippy --workspace --all-targets --all-features
 
+  lint:
+    name: Additional Linting Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate lockfile
+        run: cargo generate-lockfile
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      # Run additional lint checks script
+      - shell: bash
+        run: ./scripts/lint.sh
+
   coverage:
     name: Code coverage check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      # Install Rust and required components
+      # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if egrep --exclude=\*.sh --exclude=CHANGELOG.md --exclude-dir=.git --exclude-dir=target -Rinw ../ -e '\<(unwrap|expect|panic|TODO|FIXME)\>'; then
+  echo "***** MATCHES FOUND ******"
+  exit 1
+else
+  echo "No matches to the specified string(s) found"
+  exit 0
+fi


### PR DESCRIPTION
Additional lints check searches for `unwrap`, `expect`, `panic`, `TODO` and `FIXME`. If there are any matches to any of these phrases in the code base (excl. the .git & target directories and CHANGELOG.md) it will show as a failure in CI. The intention is to initially have this as a not required CI stage across the board, and gradually make it required as crates are updated to remove any occurrences of these phrases.