### PR TITLE
Make the crate agnostic of the serialization format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 name = "bls_signature_aggregator"
 version = "0.1.7"
 dependencies = [
- "err-derive",
  "rand",
  "serde",
+ "thiserror",
  "threshold_crypto",
  "tiny-keccak",
 ]
@@ -63,20 +63,6 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "err-derive"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "failure"
@@ -238,34 +224,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -336,17 +298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "rustversion"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -387,6 +338,26 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -423,12 +394,6 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
-
-[[package]]
-name = "version_check"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,24 +36,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
-dependencies = [
- "byteorder",
- "serde",
-]
-
-[[package]]
 name = "bls_signature_aggregator"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
- "bincode",
  "err-derive",
  "rand",
  "serde",
- "sn_fake_clock",
  "threshold_crypto",
  "tiny-keccak",
 ]
@@ -377,12 +365,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "sn_fake_clock"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3bb89541a5068ba2861181892745587897765ea2724b78257eb5f289de16ab"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,8 @@ version = "0.1.7"
 edition = "2018"
 
 [dependencies]
-bincode = "1.2.1"
 err-derive = "~0.2.4"
 threshold_crypto = "~0.4.0"
-
-  [dependencies.sn_fake_clock]
-  version = "~0.4.0"
-  optional = true
 
   [dependencies.serde]
   version = "1.0.111"
@@ -28,6 +23,3 @@ threshold_crypto = "~0.4.0"
 
 [dev-dependencies]
 rand = "~0.7.3"
-
-[features]
-mock_timer = [ "sn_fake_clock" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.7"
 edition = "2018"
 
 [dependencies]
-err-derive = "~0.2.4"
+thiserror = "1"
 threshold_crypto = "~0.4.0"
 
   [dependencies.serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,4 @@ pub mod proof;
 pub mod signature_aggregator;
 
 pub use proof::{Proof, ProofShare};
-pub use signature_aggregator::{AccumulationError, SignatureAggregator};
+pub use signature_aggregator::{Error, SignatureAggregator};

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -17,20 +17,20 @@ use thiserror::Error;
 use threshold_crypto as bls;
 use tiny_keccak::{Hasher, Sha3};
 
-/// Default duration since their last modification after which all unaccumulated entries expire.
+/// Default duration since their last modification after which all unaggregated entries expire.
 pub const DEFAULT_EXPIRATION: Duration = Duration::from_secs(120);
 
 type Digest256 = [u8; 32];
 
-/// Accumulator for signature shares for arbitrary payloads.
+/// Aggregator for signature shares for arbitrary payloads.
 ///
-/// This accumulator allows to collect BLS signature shares for some payload one by one until enough
+/// This aggregator allows to collect BLS signature shares for some payload one by one until enough
 /// of them are collected. At that point it combines them into a full BLS signature of the given
 /// payload. It also automatically rejects invalid signature shares and expires entries that did not
 /// collect enough signature shares within a given time.
 ///
-/// This accumulator also handles the case when the same payload is signed with a signature share
-/// corresponding to a different BLS public key. In that case, the payloads will be accumulated
+/// This aggregator also handles the case when the same payload is signed with a signature share
+/// corresponding to a different BLS public key. In that case, the payloads will be aggregated
 /// separately. This avoids mixing signature shares created from different curves which would
 /// otherwise lead to invalid signature to be produced even though all the shares are valid.
 ///
@@ -40,12 +40,12 @@ pub struct SignatureAggregator {
 }
 
 impl SignatureAggregator {
-    /// Create new accumulator with default expiration.
+    /// Create new aggregator with default expiration.
     pub fn new() -> Self {
         Self::with_expiration(DEFAULT_EXPIRATION)
     }
 
-    /// Create new accumulator with the given expiration.
+    /// Create new aggregator with the given expiration.
     pub fn with_expiration(expiration: Duration) -> Self {
         Self {
             map: Default::default(),
@@ -53,26 +53,19 @@ impl SignatureAggregator {
         }
     }
 
-    /// Add new share into the accumulator. If enough valid signature shares were collected, returns
+    /// Add new share into the aggregator. If enough valid signature shares were collected, returns
     /// its `Proof` (signature + public key). Otherwise returns error which details why the
-    /// accumulation did not succeed yet.
+    /// aggregation did not succeed yet.
     ///
-    /// Note: returned `AccumulationError::NotEnoughShares` does not indicate a failure. It simply
-    /// means more shares still need to be added for that particular payload. Similarly,
-    /// `AccumulationError::AlreadyAccumulated` means the signature was already accumulated and
-    /// adding more shares has no effect. These two errors could be safely ignored (they might
-    /// still be useful perhaps for debugging). The other error variants, however, indicate
-    /// failures and should be treated a such. See [AccumulationError]
-    /// for more info.
-    pub fn add(
-        &mut self,
-        payload: &[u8],
-        proof_share: ProofShare,
-    ) -> Result<Proof, AccumulationError> {
+    /// Note: returned `Error::NotEnoughShares` does not indicate a failure. It simply means more
+    /// shares still need to be added for that particular payload. This error could be safely
+    /// ignored (it might still be useful perhaps for debugging). The other error variants, however,
+    /// indicate failures and should be treated a such. See [Error] for more info.
+    pub fn add(&mut self, payload: &[u8], proof_share: ProofShare) -> Result<Proof, Error> {
         self.remove_expired();
 
         if !proof_share.verify(payload) {
-            return Err(AccumulationError::InvalidShare);
+            return Err(Error::InvalidShare);
         }
 
         // Use the hash of the payload + the public key as the key in the map to avoid mixing
@@ -108,15 +101,15 @@ impl Default for SignatureAggregator {
     }
 }
 
-/// Error returned from SignatureAccumulator::add.
+/// Error returned from SignatureAggregator::add.
 #[derive(Debug, Error)]
-pub enum AccumulationError {
+pub enum Error {
     /// There are not enough signature shares yet, more need to be added. This is not a failure.
     #[error("not enough signature shares")]
     NotEnoughShares,
     /// The signature share being added is invalid. Such share is rejected but the already collected
     /// shares are kept intact. If enough new valid shares are collected afterwards, the
-    /// accumulation might still succeed.
+    /// aggregation might still succeed.
     #[error("signature share is invalid")]
     InvalidShare,
     /// The signature combination failed even though there are enough valid signature shares. This
@@ -139,7 +132,7 @@ impl State {
         }
     }
 
-    fn add(&mut self, proof_share: ProofShare) -> Result<bls::Signature, AccumulationError> {
+    fn add(&mut self, proof_share: ProofShare) -> Result<bls::Signature, Error> {
         if self
             .shares
             .insert(proof_share.index, proof_share.signature_share)
@@ -148,19 +141,19 @@ impl State {
             self.modified = Instant::now();
         } else {
             // Duplicate share
-            return Err(AccumulationError::NotEnoughShares);
+            return Err(Error::NotEnoughShares);
         }
 
         if self.shares.len() > proof_share.public_key_set.threshold() {
             let signature = proof_share
                 .public_key_set
                 .combine_signatures(self.shares.iter().map(|(&index, share)| (index, share)))
-                .map_err(AccumulationError::Combine)?;
+                .map_err(Error::Combine)?;
             self.shares.clear();
 
             Ok(signature)
         } else {
-            Err(AccumulationError::NotEnoughShares)
+            Err(Error::NotEnoughShares)
         }
     }
 }
@@ -177,33 +170,33 @@ mod tests {
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
 
-        let mut accumulator = SignatureAggregator::default();
+        let mut aggregator = SignatureAggregator::default();
         let payload = b"hello";
 
         // Not enough shares yet
         for index in 0..threshold {
             let proof_share = create_proof_share(&sk_set, index, payload);
             println!("{:?}", proof_share);
-            let result = accumulator.add(payload, proof_share);
+            let result = aggregator.add(payload, proof_share);
 
             match result {
-                Err(AccumulationError::NotEnoughShares) => (),
+                Err(Error::NotEnoughShares) => (),
                 _ => panic!("unexpected result: {:?}", result),
             }
         }
 
         // Enough shares now
         let proof_share = create_proof_share(&sk_set, threshold, payload);
-        let proof = accumulator.add(payload, proof_share).unwrap();
+        let proof = aggregator.add(payload, proof_share).unwrap();
 
         assert!(proof.verify(payload));
 
         // Extra shares start another round
         let proof_share = create_proof_share(&sk_set, threshold + 1, payload);
-        let result = accumulator.add(payload, proof_share);
+        let result = aggregator.add(payload, proof_share);
 
         match result {
-            Err(AccumulationError::NotEnoughShares) => (),
+            Err(Error::NotEnoughShares) => (),
             _ => panic!("unexpected result: {:?}", result),
         }
     }
@@ -214,28 +207,28 @@ mod tests {
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
 
-        let mut accumulator = SignatureAggregator::new();
+        let mut aggregator = SignatureAggregator::new();
         let payload = b"good";
 
         // First insert less than threshold + 1 valid shares.
         for index in 0..threshold {
             let proof_share = create_proof_share(&sk_set, index, payload);
-            let _ = accumulator.add(payload, proof_share);
+            let _ = aggregator.add(payload, proof_share);
         }
 
         // Then try to insert invalid share.
         let invalid_proof_share = create_proof_share(&sk_set, threshold, b"bad");
-        let result = accumulator.add(payload, invalid_proof_share);
+        let result = aggregator.add(payload, invalid_proof_share);
 
         match result {
-            Err(AccumulationError::InvalidShare) => (),
+            Err(Error::InvalidShare) => (),
             _ => panic!("unexpected result: {:?}", result),
         }
 
-        // The invalid share doesn't spoil the accumulation - we can still accumulate once enough
+        // The invalid share doesn't spoil the aggregation - we can still aggregate once enough
         // valid shares are inserted.
         let proof_share = create_proof_share(&sk_set, threshold + 1, payload);
-        let proof = accumulator.add(payload, proof_share).unwrap();
+        let proof = aggregator.add(payload, proof_share).unwrap();
         assert!(proof.verify(payload))
     }
 
@@ -245,22 +238,22 @@ mod tests {
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
 
-        let mut accumulator = SignatureAggregator::with_expiration(Duration::from_millis(500));
+        let mut aggregator = SignatureAggregator::with_expiration(Duration::from_millis(500));
         let payload = b"hello";
 
         for index in 0..threshold {
             let proof_share = create_proof_share(&sk_set, index, payload);
-            let _ = accumulator.add(payload, proof_share);
+            let _ = aggregator.add(payload, proof_share);
         }
 
         sleep(Duration::from_secs(1));
 
         // Adding another share does nothing now, because the previous shares expired.
         let proof_share = create_proof_share(&sk_set, threshold, payload);
-        let result = accumulator.add(payload, proof_share);
+        let result = aggregator.add(payload, proof_share);
 
         match result {
-            Err(AccumulationError::NotEnoughShares) => (),
+            Err(Error::NotEnoughShares) => (),
             _ => panic!("unexpected result: {:?}", result),
         }
     }
@@ -271,7 +264,7 @@ mod tests {
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
 
-        let mut accumulator = SignatureAggregator::new();
+        let mut aggregator = SignatureAggregator::new();
 
         let payload = b"hello";
 
@@ -279,11 +272,11 @@ mod tests {
 
         for index in 0..threshold {
             let proof_share = create_proof_share(&sk_set, index, payload);
-            assert!(accumulator.add(payload, proof_share).is_err());
+            assert!(aggregator.add(payload, proof_share).is_err());
         }
 
         let proof_share = create_proof_share(&sk_set, threshold, payload);
-        assert!(accumulator.add(payload, proof_share).is_ok());
+        assert!(aggregator.add(payload, proof_share).is_ok());
 
         // round 2
 
@@ -291,11 +284,11 @@ mod tests {
 
         for index in offset..(threshold + offset) {
             let proof_share = create_proof_share(&sk_set, index, payload);
-            assert!(accumulator.add(payload, proof_share).is_err());
+            assert!(aggregator.add(payload, proof_share).is_err());
         }
 
         let proof_share = create_proof_share(&sk_set, threshold + offset + 1, payload);
-        assert!(accumulator.add(payload, proof_share).is_ok());
+        assert!(aggregator.add(payload, proof_share).is_ok());
     }
 
     fn create_proof_share(sk_set: &bls::SecretKeySet, index: usize, payload: &[u8]) -> ProofShare {

--- a/src/signature_aggregator.rs
+++ b/src/signature_aggregator.rs
@@ -9,32 +9,18 @@
 
 use super::proof::{Proof, ProofShare};
 use err_derive::Error;
-use serde::Serialize;
-use std::time::Duration;
-use std::{collections::HashMap, fmt::Debug};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    time::{Duration, Instant},
+};
 use threshold_crypto as bls;
-
-#[cfg(feature = "mock_timer")]
-use sn_fake_clock::FakeClock as Instant;
-#[cfg(not(feature = "mock_timer"))]
-use std::time::Instant;
-
-/// SHA3-256 hash digest.
-pub type Digest256 = [u8; 32];
-
-/// SHA3-256 hash function.
-pub fn sha3_256(input: &[u8]) -> Digest256 {
-    use tiny_keccak::{Hasher, Sha3};
-
-    let mut hasher = Sha3::v256();
-    let mut output = Digest256::default();
-    hasher.update(input);
-    hasher.finalize(&mut output);
-    output
-}
+use tiny_keccak::{Hasher, Sha3};
 
 /// Default duration since their last modification after which all unaccumulated entries expire.
 pub const DEFAULT_EXPIRATION: Duration = Duration::from_secs(120);
+
+type Digest256 = [u8; 32];
 
 /// Accumulator for signature shares for arbitrary payloads.
 ///
@@ -42,18 +28,6 @@ pub const DEFAULT_EXPIRATION: Duration = Duration::from_secs(120);
 /// of them are collected. At that point it combines them into a full BLS signature of the given
 /// payload. It also automatically rejects invalid signature shares and expires entries that did not
 /// collect enough signature shares within a given time.
-///
-/// The accumulated payload needs to implement `Serialize` which is used in two ways:
-///
-/// 1. to calculate a cryptographic hash of the payload which is then used to compute the
-///    accumulation key.
-///    This means that two signature shares with payloads that serialize into the same byte sequence
-///    are accumulated together.
-/// 2. to verify the signature share - the serialized payload is what is passed to the `verify`
-///    function.
-///
-/// The serialization is performed using `bincode::serialize` which also needs to be used to
-/// create the signature share.
 ///
 /// This accumulator also handles the case when the same payload is signed with a signature share
 /// corresponding to a different BLS public key. In that case, the payloads will be accumulated
@@ -80,8 +54,8 @@ impl SignatureAggregator {
     }
 
     /// Add new share into the accumulator. If enough valid signature shares were collected, returns
-    /// the payload and its corresponding `Proof` (signature + public key). Otherwise returns error
-    /// which details why the accumulation did not succeed yet.
+    /// its `Proof` (signature + public key). Otherwise returns error which details why the
+    /// accumulation did not succeed yet.
     ///
     /// Note: returned `AccumulationError::NotEnoughShares` does not indicate a failure. It simply
     /// means more shares still need to be added for that particular payload. Similarly,
@@ -90,44 +64,34 @@ impl SignatureAggregator {
     /// still be useful perhaps for debugging). The other error variants, however, indicate
     /// failures and should be treated a such. See [AccumulationError]
     /// for more info.
-    ///
-    /// Note: the `signature_share` field in the `proof_share` must be created by serializing the
-    /// `payload` with `bincode::serialize` and signing the resulting bytes. Other serialization
-    /// formats are not currently supported.
-    pub fn add<T>(
+    pub fn add(
         &mut self,
-        payload: T,
+        payload: &[u8],
         proof_share: ProofShare,
-    ) -> Result<(T, Proof), AccumulationError>
-    where
-        T: Serialize,
-    {
+    ) -> Result<Proof, AccumulationError> {
         self.remove_expired();
 
-        let mut bytes = bincode::serialize(&payload)?;
-
-        if !proof_share.verify(&bytes) {
+        if !proof_share.verify(payload) {
             return Err(AccumulationError::InvalidShare);
         }
 
         // Use the hash of the payload + the public key as the key in the map to avoid mixing
         // entries that have the same payload but are signed using different keys.
         let public_key = proof_share.public_key_set.public_key();
-        bytes.extend_from_slice(&public_key.to_bytes());
-        let hash = sha3_256(&bytes);
+
+        let mut hasher = Sha3::v256();
+        let mut hash = Digest256::default();
+        hasher.update(payload);
+        hasher.update(&public_key.to_bytes());
+        hasher.finalize(&mut hash);
 
         self.map
             .entry(hash)
             .or_insert_with(State::new)
-            .add(payload, proof_share)
-            .map(|(payload, signature)| {
-                (
-                    payload,
-                    Proof {
-                        public_key,
-                        signature,
-                    },
-                )
+            .add(proof_share)
+            .map(|signature| Proof {
+                public_key,
+                signature,
             })
     }
 
@@ -155,12 +119,6 @@ pub enum AccumulationError {
     /// accumulation might still succeed.
     #[error(display = "signature share is invalid")]
     InvalidShare,
-    /// The payload failed to be serialised and can't be inserted into the accumulator. This doesn't
-    /// affect other entries already present and the accumulator can still be used normally
-    /// afterwards. In practice, this error should never happen unless the host machine runs out of
-    /// memory or a similar catastrophic failure.
-    #[error(display = "failed to serialise payload: {}", _0)]
-    Serialise(#[error(source)] bincode::Error),
     /// The signature combination failed even though there are enough valid signature shares. This
     /// should probably never happen.
     #[error(display = "failed to combine signature shares: {}", _0)]
@@ -180,11 +138,7 @@ impl State {
         }
     }
 
-    fn add<T>(
-        &mut self,
-        payload: T,
-        proof_share: ProofShare,
-    ) -> Result<(T, bls::Signature), AccumulationError> {
+    fn add(&mut self, proof_share: ProofShare) -> Result<bls::Signature, AccumulationError> {
         if self
             .shares
             .insert(proof_share.index, proof_share.signature_share)
@@ -202,7 +156,7 @@ impl State {
                 .combine_signatures(self.shares.iter().map(|(&index, share)| (index, share)))?;
             self.shares.clear();
 
-            Ok((payload, signature))
+            Ok(signature)
         } else {
             Err(AccumulationError::NotEnoughShares)
         }
@@ -222,13 +176,13 @@ mod tests {
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
 
         let mut accumulator = SignatureAggregator::default();
-        let payload = "hello".to_string();
+        let payload = b"hello";
 
         // Not enough shares yet
         for index in 0..threshold {
-            let proof_share = create_proof_share(&sk_set, index, &payload);
+            let proof_share = create_proof_share(&sk_set, index, payload);
             println!("{:?}", proof_share);
-            let result = accumulator.add(payload.clone(), proof_share);
+            let result = accumulator.add(payload, proof_share);
 
             match result {
                 Err(AccumulationError::NotEnoughShares) => (),
@@ -237,14 +191,13 @@ mod tests {
         }
 
         // Enough shares now
-        let proof_share = create_proof_share(&sk_set, threshold, &payload);
-        let (accumulated_payload, proof) = accumulator.add(payload.clone(), proof_share).unwrap();
+        let proof_share = create_proof_share(&sk_set, threshold, payload);
+        let proof = accumulator.add(payload, proof_share).unwrap();
 
-        assert_eq!(accumulated_payload, payload);
-        assert!(proof.verify(&bincode::serialize(&accumulated_payload).unwrap()));
+        assert!(proof.verify(payload));
 
         // Extra shares start another round
-        let proof_share = create_proof_share(&sk_set, threshold + 1, &payload);
+        let proof_share = create_proof_share(&sk_set, threshold + 1, payload);
         let result = accumulator.add(payload, proof_share);
 
         match result {
@@ -260,17 +213,17 @@ mod tests {
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
 
         let mut accumulator = SignatureAggregator::new();
-        let payload = "good".to_string();
+        let payload = b"good";
 
         // First insert less than threshold + 1 valid shares.
         for index in 0..threshold {
-            let proof_share = create_proof_share(&sk_set, index, &payload);
-            let _ = accumulator.add(payload.clone(), proof_share);
+            let proof_share = create_proof_share(&sk_set, index, payload);
+            let _ = accumulator.add(payload, proof_share);
         }
 
         // Then try to insert invalid share.
-        let invalid_proof_share = create_proof_share(&sk_set, threshold, &"bad".to_string());
-        let result = accumulator.add(payload.clone(), invalid_proof_share);
+        let invalid_proof_share = create_proof_share(&sk_set, threshold, b"bad");
+        let result = accumulator.add(payload, invalid_proof_share);
 
         match result {
             Err(AccumulationError::InvalidShare) => (),
@@ -279,9 +232,9 @@ mod tests {
 
         // The invalid share doesn't spoil the accumulation - we can still accumulate once enough
         // valid shares are inserted.
-        let proof_share = create_proof_share(&sk_set, threshold + 1, &payload);
-        let (accumulated_payload, proof) = accumulator.add(payload, proof_share).unwrap();
-        assert!(proof.verify(&bincode::serialize(&accumulated_payload).unwrap()))
+        let proof_share = create_proof_share(&sk_set, threshold + 1, payload);
+        let proof = accumulator.add(payload, proof_share).unwrap();
+        assert!(proof.verify(payload))
     }
 
     #[test]
@@ -290,18 +243,18 @@ mod tests {
         let threshold = 3;
         let sk_set = bls::SecretKeySet::random(threshold, &mut rng);
 
-        let mut accumulator = SignatureAggregator::with_expiration(Duration::from_secs(3));
-        let payload = "hello".to_string();
+        let mut accumulator = SignatureAggregator::with_expiration(Duration::from_millis(500));
+        let payload = b"hello";
 
         for index in 0..threshold {
-            let proof_share = create_proof_share(&sk_set, index, &payload);
-            let _ = accumulator.add(payload.clone(), proof_share);
+            let proof_share = create_proof_share(&sk_set, index, payload);
+            let _ = accumulator.add(payload, proof_share);
         }
 
-        sleep(Duration::from_secs(5));
+        sleep(Duration::from_secs(1));
 
         // Adding another share does nothing now, because the previous shares expired.
-        let proof_share = create_proof_share(&sk_set, threshold, &payload);
+        let proof_share = create_proof_share(&sk_set, threshold, payload);
         let result = accumulator.add(payload, proof_share);
 
         match result {
@@ -318,43 +271,33 @@ mod tests {
 
         let mut accumulator = SignatureAggregator::new();
 
-        let payload = "hello".to_string();
+        let payload = b"hello";
 
         // round 1
 
         for index in 0..threshold {
-            let proof_share = create_proof_share(&sk_set, index, &payload);
-            assert!(accumulator.add(payload.clone(), proof_share).is_err());
+            let proof_share = create_proof_share(&sk_set, index, payload);
+            assert!(accumulator.add(payload, proof_share).is_err());
         }
 
-        let proof_share = create_proof_share(&sk_set, threshold, &payload);
-        assert!(accumulator.add(payload.clone(), proof_share).is_ok());
+        let proof_share = create_proof_share(&sk_set, threshold, payload);
+        assert!(accumulator.add(payload, proof_share).is_ok());
 
         // round 2
 
         let offset = 2;
 
         for index in offset..(threshold + offset) {
-            let proof_share = create_proof_share(&sk_set, index, &payload);
-            assert!(accumulator.add(payload.clone(), proof_share).is_err());
+            let proof_share = create_proof_share(&sk_set, index, payload);
+            assert!(accumulator.add(payload, proof_share).is_err());
         }
 
-        let proof_share = create_proof_share(&sk_set, threshold + offset + 1, &payload);
+        let proof_share = create_proof_share(&sk_set, threshold + offset + 1, payload);
         assert!(accumulator.add(payload, proof_share).is_ok());
     }
 
-    fn create_proof_share<T: Serialize>(
-        sk_set: &bls::SecretKeySet,
-        index: usize,
-        payload: &T,
-    ) -> ProofShare {
+    fn create_proof_share(sk_set: &bls::SecretKeySet, index: usize, payload: &[u8]) -> ProofShare {
         let sk_share = sk_set.secret_key_share(index);
-
-        ProofShare::new(
-            sk_set.public_keys(),
-            index,
-            &sk_share,
-            &bincode::serialize(&payload).unwrap(),
-        )
+        ProofShare::new(sk_set.public_keys(), index, &sk_share, &payload)
     }
 }


### PR DESCRIPTION
Also remove fake_clock, rename `AccumulationError` to just `Error` and change `accumulator` to `aggregator` across the board for consistency.