### PR TITLE
chore: remove Cargo.lock from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.idea
+*.lock


### PR DESCRIPTION
No need to keep this in version control.