### PR TITLE
chore(ci): add geiger scan to ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,10 +29,6 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-        # Generate Cargo.lock, needed for the cache.
-      - name: Generate lockfile
-        run: cargo generate-lockfile
-
       # Cache.
       - name: Cargo cache registry, index and build
         uses: actions/cache@v2.1.4
@@ -62,6 +58,36 @@ jobs:
         with:
           max_lines_changed: 200
   
+  geiger:
+    if: ${{ github.repository_owner == 'maidsafe' }}
+    name: Cargo geiger
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install geiger
+        run: cargo install --locked cargo-geiger
+      
+      # Run cargo geiger to list statistics related to the usage of unsafe Rust code in this crate and all its dependencies.
+      - name: Run Cargo geiger
+        run: cargo geiger --all-features --all-targets --all-dependencies
+  
   coverage:
     name: Code coverage check
     runs-on: ubuntu-latest
@@ -73,10 +99,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build
@@ -149,10 +171,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-
-      # Generate Cargo.lock, needed for the cache.
-      - name: Generate lockfile
-        run: cargo generate-lockfile
 
       # Cache.
       - name: Cargo cache registry, index and build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "bls_signature_aggregator"
-version = "0.1.7"
+version = "0.2.3"
 dependencies = [
  "rand",
  "serde",


### PR DESCRIPTION
Cargo geiger lists statistics related to the usage of unsafe Rust code in a Rust crate and all its dependencies.